### PR TITLE
Add branch protection rule for main branch

### DIFF
--- a/otterdog/eclipse-symphony.jsonnet
+++ b/otterdog/eclipse-symphony.jsonnet
@@ -1,5 +1,17 @@
 local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
+# Function to create a new branch protection rule with default settings.
+# https://otterdog.readthedocs.io/en/stable/reference/organization/repository/branch-protection-rule/
+local newBranchProtectionRule(pattern) = {
+  pattern: pattern,
+  dismisses_stale_reviews: true,
+  requires_pull_request: true,
+  required_approving_review_count: 1,
+  requires_status_checks: true,
+  requires_strict_status_checks: true,
+  requires_conversation_resolution: true,
+};
+
 orgs.newOrg('eclipse-symphony') {
   settings+: {
     dependabot_security_updates_enabled_for_new_repositories: false,
@@ -16,6 +28,9 @@ orgs.newOrg('eclipse-symphony') {
       has_discussions: true,
       has_projects: false,
       has_wiki: false,
+      branch_protection_rules: [
+        newBranchProtectionRule("main"),
+      ],
     },
     orgs.newRepo('symphony-website') {
       allow_merge_commit: true,


### PR DESCRIPTION
Followed doc: https://otterdog.readthedocs.io/en/stable/reference/organization/repository/branch-protection-rule/ and added branch protection rule for main branch of Symphony repo,

-   dismisses_stale_reviews: true,
-   requires_pull_request: true,
-   required_approving_review_count: 1,
-   requires_status_checks: true,
-   requires_strict_status_checks: true,
-   requires_conversation_resolution: true,