### PR TITLE
Fix branch protection rule to allow eclipse-symphony-bot to directly push

### DIFF
--- a/otterdog/eclipse-symphony.jsonnet
+++ b/otterdog/eclipse-symphony.jsonnet
@@ -1,16 +1,5 @@
 local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
-# Function to create a new branch protection rule with default settings.
-# https://otterdog.readthedocs.io/en/stable/reference/organization/repository/branch-protection-rule/
-local newBranchProtectionRule(pattern) = orgs.newBranchProtectionRule(pattern) {
-  dismisses_stale_reviews: true,
-  requires_pull_request: true,
-  required_approving_review_count: 1,
-  requires_status_checks: true,
-  requires_strict_status_checks: true,
-  requires_conversation_resolution: true,
-};
-
 orgs.newOrg('eclipse-symphony') {
   settings+: {
     dependabot_security_updates_enabled_for_new_repositories: false,
@@ -28,7 +17,19 @@ orgs.newOrg('eclipse-symphony') {
       has_projects: false,
       has_wiki: false,
       branch_protection_rules: [
-        newBranchProtectionRule("main"),
+        # https://otterdog.readthedocs.io/en/stable/reference/organization/repository/branch-protection-rule/
+        orgs.newBranchProtectionRule("main") {
+            dismisses_stale_reviews: true,
+            requires_pull_request: true,
+            required_approving_review_count: 1,
+            requires_status_checks: true,
+            requires_strict_status_checks: true,
+            requires_conversation_resolution: true,
+            bypass_pull_request_allowances+: [
+              "@eclipse-symphony-bot",
+              "@github-actions",
+            ],
+        },
       ],
     },
     orgs.newRepo('symphony-website') {

--- a/otterdog/eclipse-symphony.jsonnet
+++ b/otterdog/eclipse-symphony.jsonnet
@@ -27,12 +27,10 @@ orgs.newOrg('eclipse-symphony') {
           dismisses_stale_reviews: true,
           requires_pull_request: true,
           required_approving_review_count: 1,
-          requires_status_checks: true,
-          requires_strict_status_checks: true,
+          requires_status_checks: false,
           requires_conversation_resolution: true,
           bypass_pull_request_allowances+: [
             "@eclipse-symphony-bot",
-            "@github-actions",
           ],
         },
       ],

--- a/otterdog/eclipse-symphony.jsonnet
+++ b/otterdog/eclipse-symphony.jsonnet
@@ -16,6 +16,11 @@ orgs.newOrg('eclipse-symphony') {
       has_discussions: true,
       has_projects: false,
       has_wiki: false,
+      secrets: [
+        orgs.newRepoSecret('BOT_GITHUB_TOKEN') {
+          value: "pass:bots/iot.symphony/github.com/api-token",
+        },
+      ],
       branch_protection_rules: [
         # https://otterdog.readthedocs.io/en/stable/reference/organization/repository/branch-protection-rule/
         orgs.newBranchProtectionRule("main") {

--- a/otterdog/eclipse-symphony.jsonnet
+++ b/otterdog/eclipse-symphony.jsonnet
@@ -19,16 +19,16 @@ orgs.newOrg('eclipse-symphony') {
       branch_protection_rules: [
         # https://otterdog.readthedocs.io/en/stable/reference/organization/repository/branch-protection-rule/
         orgs.newBranchProtectionRule("main") {
-            dismisses_stale_reviews: true,
-            requires_pull_request: true,
-            required_approving_review_count: 1,
-            requires_status_checks: true,
-            requires_strict_status_checks: true,
-            requires_conversation_resolution: true,
-            bypass_pull_request_allowances+: [
-              "@eclipse-symphony-bot",
-              "@github-actions",
-            ],
+          dismisses_stale_reviews: true,
+          requires_pull_request: true,
+          required_approving_review_count: 1,
+          requires_status_checks: true,
+          requires_strict_status_checks: true,
+          requires_conversation_resolution: true,
+          bypass_pull_request_allowances+: [
+            "@eclipse-symphony-bot",
+            "@github-actions",
+          ],
         },
       ],
     },


### PR DESCRIPTION
1. Use default newBranchProtectionRule instead of defining a new fucntion.
2. Allow github-actions, eclipse-symphony-bot the direct push permission. We have release pipeline - https://github.com/eclipse-symphony/symphony/actions/runs/8929609240 to bump up version file which requires the direct push permission.